### PR TITLE
Added support for specifying variables from a file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 Sébastien Lavoie
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ VAR=value templater.sh template
 Read variables from file:
     
 ```bash
-template.sh template -f variables.txt
+templater.sh template -f variables.txt
 ```
 
 Don't print any warning messages:
 
 ```bash
-template.sh template -f variables.txt -s
+templater.sh template -f variables.txt -s
 ```
 
 ## Examples

--- a/README.md
+++ b/README.md
@@ -5,12 +5,27 @@ Supports default values by writting {{VAR=value}} in the template
 ## Author
 
 Sébastien Lavoie <github@lavoie.sl>
+Johan Haleby
 
 See http://blog.lavoie.sl/2012/11/simple-templating-system-using-bash.html for other details
 
 ## Usage
-
+	
+	```bash
     VAR=value templater.sh template
+    ```
+
+    Read variables from file:
+    
+    ```bash
+    template.sh template -f variables.txt
+    ```
+
+    Don't print any warning messages:
+
+    ```bash
+    template.sh template -f variables.txt -s
+    ```
 
 ## Examples
 See examples/

--- a/README.md
+++ b/README.md
@@ -5,27 +5,28 @@ Supports default values by writting {{VAR=value}} in the template
 ## Author
 
 Sébastien Lavoie <github@lavoie.sl>
+
 Johan Haleby
 
 See http://blog.lavoie.sl/2012/11/simple-templating-system-using-bash.html for other details
 
 ## Usage
 	
-	```bash
-    VAR=value templater.sh template
-    ```
+```bash
+VAR=value templater.sh template
+```
 
-    Read variables from file:
+Read variables from file:
     
-    ```bash
-    template.sh template -f variables.txt
-    ```
+```bash
+template.sh template -f variables.txt
+```
 
-    Don't print any warning messages:
+Don't print any warning messages:
 
-    ```bash
-    template.sh template -f variables.txt -s
-    ```
+```bash
+template.sh template -f variables.txt -s
+```
 
 ## Examples
 See examples/

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Sébastien Lavoie <github@lavoie.sl>
 
 Johan Haleby
 
-See http://blog.lavoie.sl/2012/11/simple-templating-system-using-bash.html for other details
+See http://code.haleby.se/2015/11/20/simple-templating-engine-in-bash/  and http://blog.lavoie.sl/2012/11/simple-templating-system-using-bash.html for more details
 
 ## Usage
 	

--- a/README.md
+++ b/README.md
@@ -22,6 +22,15 @@ Read variables from file:
 templater.sh template -f variables.txt
 ```
 
+e.g.:
+```bash
+# variables.txt
+# The author
+AUTHOR=Johan
+# The version
+VERSION=1.2.3
+```
+
 Don't print any warning messages:
 
 ```bash

--- a/templater.sh
+++ b/templater.sh
@@ -86,7 +86,7 @@ if [ "${config_file}" != "<none>" ]; then
 
     # Create temp file where & and "space" is escaped
     tmpfile=`mktemp`   
-    sed -e "s;\&;\\\&;g" -e "s;\ ;\\\ ;g" ${config_file} > $tmpfile
+    sed -e "s;\&;\\\&;g" -e "s;\ ;\\\ ;g" "${config_file}" > $tmpfile
     source $tmpfile
 fi    
 
@@ -130,14 +130,14 @@ fi
 for var in $vars; do
     value=`var_value $var`
     if [[ -z "$value" ]]; then
-        if [ $silent == "false" ]; then    
+        if [ $silent == "false" ]; then
             echo "Warning: $var is not defined and no default is set, replacing by empty" >&2
         fi
     fi
 
     # Escape slashes
     value=$(echo "$value" | sed 's/\//\\\//g');
-    replaces="-e 's;{{$var}};${value};g' $replaces"    
+    replaces="-e 's/{{$var}}/${value}/g' $replaces"    
 done
 
 escaped_template_path=$(echo $template | sed 's/ /\\ /g')

--- a/templater.sh
+++ b/templater.sh
@@ -25,7 +25,9 @@
 # SOFTWARE.
 #
 # See: https://github.com/johanhaleby/bash-templater
-# Version: https://github.com/johanhaleby/bash-templater/commit/5ac655d554238ac70b08ee4361d699ea9954c941# Replaces all {{VAR}} by the $VAR value in a template file and outputs it
+# Version: https://github.com/johanhaleby/bash-templater/commit/5ac655d554238ac70b08ee4361d699ea9954c941
+
+# Replaces all {{VAR}} by the $VAR value in a template file and outputs it
 
 readonly PROGNAME=$(basename $0)
 

--- a/templater.sh
+++ b/templater.sh
@@ -3,7 +3,6 @@
 
 readonly PROGNAME=$(basename $0)
 
-template_file="${1}"
 config_file="<none>"
 print_only="false"
 silent="false"
@@ -69,11 +68,11 @@ if [ "$#" -ne 0 ]; then
     done
 fi
 
-vars=$(grep -oE '\{\{[A-Za-z0-9_]+\}\}' "$template" | sort | uniq | sed -e 's/^{{//' -e 's/}}$//')
+vars=$(grep -oE '\{\{[A-Za-z0-9_]+\}\}' "${template}" | sort | uniq | sed -e 's/^{{//' -e 's/}}$//')
 
 if [[ -z "$vars" ]]; then
     if [ "$silent" == "false" ]; then
-        echo "Warning: No variable was found in $template, syntax is {{VAR}}" >&2
+        echo "Warning: No variable was found in ${template}, syntax is {{VAR}}" >&2
     fi
 fi
 
@@ -97,7 +96,8 @@ replaces=""
 # Reads default values defined as {{VAR=value}} and delete those lines
 # There are evaluated, so you can do {{PATH=$HOME}} or {{PATH=`pwd`}}
 # You can even reference variables defined in the template before
-defaults=$(grep -oE '^\{\{[A-Za-z0-9_]+=.+\}\}' "$template" | sed -e 's/^{{//' -e 's/}}$//')
+defaults=$(grep -oE '^\{\{[A-Za-z0-9_]+=.+\}\}' "${template}" | sed -e 's/^{{//' -e 's/}}$//')
+
 for default in $defaults; do
     var=$(echo "$default" | grep -oE "^[A-Za-z0-9_]+")
     current=`var_value $var`
@@ -137,4 +137,5 @@ for var in $vars; do
     replaces="-e 's/{{$var}}/$value/g' $replaces"
 done
 
-eval sed $replaces "$template"
+escaped_template_path=$(echo $template | sed 's/ /\\ /g')
+eval sed $replaces "$escaped_template_path"

--- a/templater.sh
+++ b/templater.sh
@@ -84,7 +84,10 @@ if [ "${config_file}" != "<none>" ]; then
       exit 1
     fi
 
-    source "${config_file}"
+    # Create temp file
+    tmpfile=`mktemp`   
+    sed -e "s;\&;\\\&;g" ${config_file} > $tmpfile    
+    source $tmpfile
 fi    
 
 var_value() {

--- a/templater.sh
+++ b/templater.sh
@@ -84,9 +84,9 @@ if [ "${config_file}" != "<none>" ]; then
       exit 1
     fi
 
-    # Create temp file
+    # Create temp file where & and "space" is escaped
     tmpfile=`mktemp`   
-    sed -e "s;\&;\\\&;g" ${config_file} > $tmpfile    
+    sed -e "s;\&;\\\&;g" -e "s;\ ;\\\ ;g" ${config_file} > $tmpfile
     source $tmpfile
 fi    
 
@@ -137,7 +137,7 @@ for var in $vars; do
 
     # Escape slashes
     value=$(echo "$value" | sed 's/\//\\\//g');
-    replaces="-e 's/{{$var}}/$value/g' $replaces"
+    replaces="-e 's;{{$var}};${value};g' $replaces"    
 done
 
 escaped_template_path=$(echo $template | sed 's/ /\\ /g')

--- a/templater.sh
+++ b/templater.sh
@@ -1,5 +1,31 @@
 #!/bin/bash
-# Replaces all {{VAR}} by the $VAR value in a template file and outputs it
+#
+# Very simple templating system that replaces {{VAR}} by the value of $VAR.
+# Supports default values by writting {{VAR=value}} in the template.
+#
+# Copyright (c) 2017 Sébastien Lavoie
+# Copyright (c) 2017 Johan Haleby
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# See: https://github.com/johanhaleby/bash-templater
+# Version: https://github.com/johanhaleby/bash-templater/commit/5ac655d554238ac70b08ee4361d699ea9954c941# Replaces all {{VAR}} by the $VAR value in a template file and outputs it
 
 readonly PROGNAME=$(basename $0)
 


### PR DESCRIPTION
You can now do:

``` bash
template.sh template -f variables.txt
```

`variables.txt` can contains variables such as:

``` bash
# The author
AUTHOR=Johan
# The version
VERSION=1.2.3
```

You can also silence the warning messages by added `-s`.
